### PR TITLE
Bugfix for MOD(X,0) and mod. of Py scripts

### DIFF
--- a/HRLDAS/HRLDAS_forcing/create_forcing_netcdf.F
+++ b/HRLDAS/HRLDAS_forcing/create_forcing_netcdf.F
@@ -95,6 +95,7 @@ program create_forcing
   integer :: ihour
   integer :: numarg
   integer :: unmatched
+  logical :: proc_ic
 #ifndef _GFORTRAN_
   ! For some reason, gfortran does not like this declared external,
   ! but everyone else wants it declared external.  So we use #ifndef
@@ -445,7 +446,17 @@ program create_forcing
      call error_handler(ierr, "Problem closing Netcdf file")
 
      if ( full_ic_frq > -1 ) then  ! full_ic_frq == -1 turns off extra processing for initial conditions.
-        if ( ( (full_ic_frq>0) .and. (mod(ihour, full_ic_frq)==0) ) .or. ( ihour==0 ) ) then
+        
+        ! Workaround for problem with mod( , 0) --> Invalid arithmetic operation
+        proc_ic = .False.
+        if ( full_ic_frq>0 ) then
+           if ( mod(ihour, full_ic_frq)==0 ) then
+              proc_ic = .True.
+           end if
+        end if
+        !
+        
+        if ( ( ihour==0 ) .or. ( proc_ic .eqv. .True. ) ) then
 
            call open_netcdf_for_output( trim(OutputDir)//"HRLDAS_setup_"//date(1:4)//date(6:7)//date(9:10)//date(12:13)//"_d"//hgrid, &
              ncid, version, geo_em%idim, geo_em%jdim, geo_em, .true.)

--- a/HRLDAS/HRLDAS_forcing/run/examples/GLDAS/combine_precips_netcdf.perl
+++ b/HRLDAS/HRLDAS_forcing/run/examples/GLDAS/combine_precips_netcdf.perl
@@ -8,18 +8,18 @@ system ("make");
 	 "20","21","22","23","24","25","26","27","28","29", 
 	 "30","31");
 	 
-@yrs = ("00");
+@yrs = ("10");
 
-$day_start = 275;
-$day_end = 275;
+$day_start = 1;
+$day_end = 3;
 
 @hrs = ("00","03","06","09","12","15","18","21");
 
 @noleap_days = (0,31,59,90,120,151,181,212,243,273,304,334,365);
 @leap_days   = (0,31,60,91,121,152,182,213,244,274,305,335,366);
 
-$data_dir = "/glade/work/zhezhang/GLDAS/extracted/";
-$results_dir = "/glade/work/zhezhang/GLDAS/extracted/";
+$data_dir = "/opt/ARW/DATA/GLDAS/extracted";
+$results_dir = "/opt/ARW/DATA/GLDAS/extracted";
 
 for $yy (@yrs)
  {
@@ -32,7 +32,7 @@ for($julday=$day_start;$julday<=$day_end;$julday++)
  # This little section finds the text month and day
  
  @modays = @noleap_days;
- if($yy == "00" || $yy == "04" || $yy == "08" || $yy == "12") {@modays = @leap_days}
+ if($yy == "00" || $yy == "04" || $yy == "08" || $yy == "12" || $yy == "16" || $yy == "20" || $yy == "24" || $yy == "28") {@modays = @leap_days}
 
  for($mo=1;$mo<=12;$mo++)
   {
@@ -45,10 +45,13 @@ for($julday=$day_start;$julday<=$day_end;$julday++)
 
 for $hr (@hrs)
  {
+  system ("mkdir -p $results_dir/Precip");
+  
   $file1_in  =    "$data_dir/Rainf/GLDAS_Rainf_tavg_20$yy$nums[$mon]$nums[$day]$hr";
   $file2_in  =    "$data_dir/Snowf/GLDAS_Snowf_tavg_20$yy$nums[$mon]$nums[$day]$hr";
   $file_out  =  "$results_dir/Precip/GLDAS_Precip_20$yy$nums[$mon]$nums[$day]$hr";
-  print ("$file_out \n");
+  
+  print ("./$filename $file1_in $file2_in $file_out\n");
   system ("./$filename $file1_in $file2_in $file_out");
  }
  }

--- a/HRLDAS/HRLDAS_forcing/run/examples/GLDAS/create_UV_netcdf.perl
+++ b/HRLDAS/HRLDAS_forcing/run/examples/GLDAS/create_UV_netcdf.perl
@@ -8,18 +8,18 @@ system ("make");
 	 "20","21","22","23","24","25","26","27","28","29", 
 	 "30","31");
 	 
-@yrs = ("00");
+@yrs = ("10");
 
-$day_start = 275;
-$day_end = 275;
+$day_start = 1;
+$day_end = 3;
 
 @hrs = ("00","03","06","09","12","15","18","21");
 
 @noleap_days = (0,31,59,90,120,151,181,212,243,273,304,334,365);
 @leap_days   = (0,31,60,91,121,152,182,213,244,274,305,335,366);
 
-$data_dir = "/glade/work/zhezhang/GLDAS/extracted";
-$results_dir = "/glade/work/zhezhang/GLDAS/extracted";
+$data_dir = "/opt/ARW/DATA/GLDAS/extracted";
+$results_dir = "/opt/ARW/DATA/GLDAS/extracted";
 
 for $yy (@yrs)
  {
@@ -33,7 +33,7 @@ for($julday=$day_start;$julday<=$day_end;$julday++)
  # This little section finds the text month and day
  
  @modays = @noleap_days;
- if($yy == "00" || $yy == "04" || $yy == "08" || $yy == "12") {@modays = @leap_days}
+ if($yy == "00" || $yy == "04" || $yy == "08" || $yy == "12" || $yy == "16" || $yy == "20" || $yy == "24" || $yy == "28") {@modays = @leap_days}
 
  for($mo=1;$mo<=12;$mo++)
   {
@@ -46,17 +46,16 @@ for($julday=$day_start;$julday<=$day_end;$julday++)
 
 for $hr (@hrs)
  {
+  system ("mkdir -p $results_dir/U $results_dir/V");
 
   $file_in  =    "$data_dir/Wind/GLDAS_Wind_f_inst_20$yy$nums[$mon]$nums[$day]$hr";
   $file1_out =  " $results_dir/U/GLDAS_U_f_inst_20$yy$nums[$mon]$nums[$day]$hr";
   $file2_out =  " $results_dir/V/GLDAS_V_f_inst_20$yy$nums[$mon]$nums[$day]$hr";
 
-  print ("$file_in \n");
-  print ("$file1_out \n");
-  print ("$file2_out \n");
+  print ("./$filename $file_in $file1_out $file2_out\n");
   system ("./$filename $file_in $file1_out $file2_out");
  }
  }
  } # End of outer time loop
 
-system("rm $filename");
+ system("rm $filename");

--- a/HRLDAS/HRLDAS_forcing/run/examples/GLDAS/extract_gldas.py
+++ b/HRLDAS/HRLDAS_forcing/run/examples/GLDAS/extract_gldas.py
@@ -1,67 +1,83 @@
 #!/usr/bin/python
-### Zhe Zhang
-### 2020-04-21
-### python script to extract gldas variables
-### origional perl code from Mike's directory
-### migrate from perl to python 
+# Zhe Zhang
+# 2020-04-21
+# python script to extract gldas variables
+# origional perl code from Mike's directory
+# migrate from perl to python
 
 import glob
-import numpy as np
-import sys,os
+import os
 
-### create date arrays
-nums = ["00","01","02","03","04","05","06","07","08","09",
-        "10","11","12","13","14","15","16","17","18","19",
-        "20","21","22","23","24","25","26","27","28","29",
-        "30","31"]
-yrs  = ["00"]
-day_start = 270 
-day_end   = 280
-hrs = ["00","03","06","09","12","15","18","21"]
-cc  = ["20"]   # Manually set the century
+# Configure start and end day
+day_start = 1
+day_end = 3
 
-noleap_days = [0,31,59,90,120,151,181,212,243,273,304,334,365]
-leap_days   = [0,31,60,91,121,152,182,213,244,274,305,335,366]
-vars_name = ["Rainf_tavg","Snowf_tavg","Wind_f_inst","Tair_f_inst",
-             "Qair_f_inst","Psurf_f_inst","SWdown_f_tavg","LWdown_f_tavg"]
-vars_short= ["Rainf","Snowf","Wind","Tair",
-             "Qair","Psurf","SWdown","LWdown"]
-data_dir = "/glade/work/zhezhang/GLDAS/raw"
-results_dir = "/glade/work/zhezhang/GLDAS/extracted"
+# Set directories and file name
+data_dir = "/opt/ARW/DATA/GLDAS/raw/netcdf/"
+results_dir = "/opt/ARW/DATA/GLDAS/extracted/"
+filestem = "GLDAS_NOAH025_3H.A"
+
+# set years
+cc = ["20"]
+yrs = ["10"]
+
+# create date arrays
+nums = ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+        "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+        "20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+        "30", "31"]
+hrs = ["00", "03", "06", "09", "12", "15", "18", "21"]
+noleap_days = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365]
+leap_days = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366]
+
+# Set var names
+vars_name = ["Rainf_tavg", "Snowf_tavg", "Wind_f_inst", "Tair_f_inst",
+             "Qair_f_inst", "Psurf_f_inst", "SWdown_f_tavg", "LWdown_f_tavg"]
+vars_short = ["Rainf", "Snowf", "Wind", "Tair", "Qair", "Psurf", "SWdown",
+              "LWdown"]
 
 for var in range(len(vars_name)):
+    print("working on variable: ", vars_short[var])
     for yy in range(len(yrs)):
-        for julday in range(day_start,day_end,1):
+        for julday in range(day_start, day_end+1, 1):
+            # check for leap years and select days
             modays = noleap_days
-            if (yrs[yy] == "92" or "96"):
-		modays = leap_days
-	    if (yrs[yy] == "00" or "04" or "08" or "12" or "16"):
-		modays = leap_days
-            for mo in range(0,12,1):
-                if (julday>modays[mo] and julday<=modays[mo+1]):
-		    day = (julday - modays[mo])
-                    if (mo<9):
-		        mon = "0"+str(mo+1)
+            if (yy == "92" or yy == "96" or yy == "00" or yy == "04" or
+                yy == "08" or yy == "12" or yy == "16" or yy == "20" or
+                yy == "24" or yy == "28" or yy == "32" or yy == "36" or
+                    yy == "40" or yy == "44" or yy == "48"):
+                modays = leap_days
+            # Month loop
+            for mo in range(0, 12, 1):
+                if (julday > modays[mo] and julday <= modays[mo+1]):
+                    day = (julday - modays[mo])
+                    # Set month and day strings
+                    if (mo < 9):
+                        mon = "0"+str(mo+1)
                     else:
-		        mon = str(mo+1)
-                    if (day<10):
+                        mon = str(mo+1)
+                    if (day < 10):
                         day = "0"+str(day)
                     else:
                         day = str(day)
-		    infiles = sorted(glob.glob(data_dir+"/GLDAS_NOAH025_3H.A"+cc[0]+yrs[yy]+(mon)+(day)+"*"))
-		    if (len(infiles)>0):
-			intime      = cc[0]+yrs[yy]+(mon)+(day) 
-			infile_list = infiles
-    if not os.path.exists(results_dir+"/"+vars_short[var]):
-        os.system("mkdir "+results_dir+"/"+vars_short[var])
-    for hr in range(0,8):
-        infile = infile_list[hr]
-	print "working on file: ",intime
-        outfile= results_dir+"/"+vars_short[var]+"/GLDAS_"+vars_name[var]+"_"+intime+hrs[hr]
-	if not os.path.exists(outfile):
-	    print "working on file: ",infile
-            os.system("ncks -v "+vars_name[var]+" "+infile+" "+outfile)
-        else:
-	    print "file exist, move to next one"
+                    # Get ini files
+                    infiles = sorted(glob.glob(
+                        data_dir + filestem + cc[0] + yrs[yy] + (mon) + (day)
+                        + "*"))
+                    if (len(infiles) > 0):
+                        intime = cc[0]+yrs[yy]+(mon)+(day)
+                        infile_list = infiles
+                    if not os.path.exists(results_dir + vars_short[var]):
+                        os.system("mkdir " + results_dir + vars_short[var])
+                    for hr in range(0, 8):
+                        infile = infile_list[hr]
+                        outfile = results_dir + vars_short[var] + "/GLDAS_" + \
+                            vars_name[var] + "_" + intime + hrs[hr]
+                        if not os.path.exists(outfile):
+                            print("writing file: ", outfile)
+                            os.system("ncks -v " + vars_name[var] + " "
+                                      + infile + " " + outfile)
+                        else:
+                            print("file exist, move to next one")
 
-print "Successfully extract necessary variables!"
+print("Successfully extracted necessary variables!")

--- a/HRLDAS/HRLDAS_forcing/run/examples/GLDAS/extract_gldas_init.py
+++ b/HRLDAS/HRLDAS_forcing/run/examples/GLDAS/extract_gldas_init.py
@@ -1,31 +1,44 @@
 #!/usr/bin/python
-### Zhe Zhang
-### 2020-04-22
-### python script to extract gldas initial conditions
-### origional perl code from Mike's directory
-### migrate from perl to python
+# Zhe Zhang
+# 2020-04-22
+# python script to extract gldas initial conditions
+# origional perl code from Mike's directory
+# migrate from perl to python
 
-import glob
-import numpy as np
-import sys,os
+import os
 
-date = "20001001" # Manually set the date
-data_dir = "/glade/work/zhezhang/GLDAS/raw"
-results_dir = "/glade/work/zhezhang/GLDAS/extracted/INIT"
+# Manually set the date for initialization
+date = "20100101"
+
+# Set directories and file name
+data_dir = "/opt/ARW/DATA/GLDAS/raw/netcdf/"
+results_dir = "/opt/ARW/DATA/GLDAS/extracted/INIT/"
+filestem = "GLDAS_NOAH025_3H.A"
+
 if not os.path.exists(results_dir):
-    os.system("mkdir "+results_dir)
+    os.system("mkdir " + results_dir)
 
-filename = data_dir+"/GLDAS_NOAH025_3H.A"+date+".0000.021.nc4"
-vars_name= ["SWE_inst","CanopInt_inst","AvgSurfT_inst","SoilMoi","SoilTMP"]
+filename = data_dir + filestem + date + ".0000.021.nc4"
+vars_name = ["SWE_inst", "CanopInt_inst", "AvgSurfT_inst", "SoilMoi",
+             "SoilTMP"]
 
 for var in range(len(vars_name)):
     if vars_name[var] == "SoilMoi" or vars_name[var] == "SoilTMP":
-        os.system("ncks -v "+vars_name[var]+"0_10cm_inst " +filename+" "+ results_dir+"/GLDAS_"+vars_name[var]+"_000-010_"+date+"00")
-        os.system("ncks -v "+vars_name[var]+"10_40cm_inst " +filename+" "+ results_dir+"/GLDAS_"+vars_name[var]+"_010-040_"+date+"00")
-        os.system("ncks -v "+vars_name[var]+"40_100cm_inst " +filename+" "+ results_dir+"/GLDAS_"+vars_name[var]+"_040-100_"+date+"00")
-        os.system("ncks -v "+vars_name[var]+"100_200cm_inst " +filename+" "+ results_dir+"/GLDAS_"+vars_name[var]+"_100-200_"+date+"00")
+        os.system("ncks -v " + vars_name[var] + "0_10cm_inst " + filename +
+                  " " + results_dir + "/GLDAS_" + vars_name[var] +
+                  "_000-010_" + date + "00")
+        os.system("ncks -v " + vars_name[var] + "10_40cm_inst " + filename +
+                  " " + results_dir + "/GLDAS_" + vars_name[var] +
+                  "_010-040_" + date + "00")
+        os.system("ncks -v " + vars_name[var] + "40_100cm_inst " + filename +
+                  " " + results_dir + "/GLDAS_" + vars_name[var] +
+                  "_040-100_" + date + "00")
+        os.system("ncks -v " + vars_name[var] + "100_200cm_inst " + filename +
+                  " " + results_dir + "/GLDAS_" + vars_name[var] +
+                  "_100-200_" + date + "00")
     else:
-	os.system("ncks -v "+vars_name[var]+" "+filename+" "+ results_dir+"/GLDAS_"+vars_name[var]+"_"+date+"00")
+        os.system("ncks -v " + vars_name[var] + " " + filename +
+                  " " + results_dir + "/GLDAS_" + vars_name[var] +
+                  "_" + date + "00")
 
-
-print "Successfully extract initial variables"
+print("Successfully extracted initial variables")

--- a/HRLDAS/IO_code/module_NoahMP_hrldas_driver.F
+++ b/HRLDAS/IO_code/module_NoahMP_hrldas_driver.F
@@ -2170,7 +2170,8 @@ end subroutine land_driver_ini
 	 
 	 ENDIF 
 
-  IF(RUNOFF_OPTION.EQ.5.AND.MOD(ITIME,STEPWTD).EQ.0)THEN
+  IF(RUNOFF_OPTION.EQ.5)THEN
+    IF(MOD(ITIME,STEPWTD).EQ.0)THEN
            CALL wrf_message('calling WTABLE' )
 
 !gmm update wtable from lateral flow and shed water to rivers
@@ -2222,8 +2223,8 @@ end subroutine land_driver_ini
 !             ENDDO                                                !urban
 !           ENDDO                                                  !urban
 !         ENDIF
-
- ENDIF
+    ENDIF
+  ENDIF
 
 !------------------------------------------------------------------------
 ! END of surface_driver consistent code


### PR DESCRIPTION
create_forcing_netcdf.F: The problem was that with my compiler (gfortran 9.3) the code checks if full_ic_frq>0 and if it is zero, it also checks (mod(ihour, full_ic_frq)==0). Then for the mod function both arguments are zero, which leads to an arithmetic error, since MOD(X,0) is not allowed. I guess that other compilers either do not check the second argument of an AND, when the first is false, or they define that MOD(x,0)=0. My workaround is long and it needs another variable. Maybe you can come up with a better solution.

module_NoahMP_hrldas_driver.F: The problem here was again that MOD(x,0) was called and an error “invalid arithmetic operation” was thrown. I took the easy way here and split the “IF AND” condition up into two IF conditions, which worked for me since I don’t use RUNOFF_OPTION 5. ;) Of course this is not a permanent solution, but I am not sure what should happen for STEPWTD==0, if the code segment should run or not, so I left it at that.

Python scripts: The indentation was not correct in my editor (Spyder 4), probably due to tabstopps. Also the print statements did not work, I had to put the arguments in brackets, maybe due to a different Python version? I am using Python 3.8. Finally, I did a lot of minor style changes, only because my editor complained about it and I wanted to get rid of the warnings. And I rearranged some code. You can ignore all these changes.